### PR TITLE
Prepare dockerhub push

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@
 FROM ubuntu:18.04 as builder
 # python needs LANG
 ENV LANG C.UTF-8
+ENV PIP_DISABLE_PIP_VERSION_CHECK 1
 
 RUN apt-get update \
     && apt-get install -y apt-utils python3 python3-distutils python3-dev python3-venv git \

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 RUN python3 -m venv /opt/tlbc-monitor
-RUN /opt/tlbc-monitor/bin/pip install pip==18.0.0 setuptools==40.0.0
+RUN /opt/tlbc-monitor/bin/pip install pip==19.0.3 setuptools==41.0.0 wheel==0.33.1
 
 COPY ./constraints.txt /tlbc-monitor/constraints.txt
 COPY ./requirements.txt /tlbc-monitor/requirements.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,13 @@
+# This will build the currently checked out version
+#
+# we use an intermediate image to build this image. it will make the resulting
+# image a bit smaller.
+#
+# you can build the image with:
+#
+#    docker build -t tlbc-monitor .
+
+
 FROM ubuntu:18.04 as builder
 # python needs LANG
 ENV LANG C.UTF-8

--- a/monitor/main.py
+++ b/monitor/main.py
@@ -3,6 +3,7 @@ import json
 from pathlib import Path
 import signal
 import time
+import pkg_resources
 
 from typing import Any, NamedTuple
 
@@ -302,6 +303,21 @@ def validate_skip_rate(ctx, param, value):
     return value
 
 
+def get_version():
+    return pkg_resources.get_distribution("tlbc-monitor").version
+
+
+def _show_version(ctx, param, value):
+    """handle --version argumemt
+
+    we need this function, because otherwise click may check that the default
+    --config or --addresses arguments are really files and they may not
+    exist"""
+    if value:
+        click.echo(get_version())
+        ctx.exit()
+
+
 @click.command()
 @click.option(
     "--rpc-uri",
@@ -352,7 +368,15 @@ def validate_skip_rate(ctx, param, value):
     help="size in seconds of the time window considered when determining if validators are offline or not",
 )
 @click.option("--sync-from", default="-1000", show_default=True, help="starting block")
+@click.option(
+    "--version",
+    help="Print tlbc-monitor version information",
+    is_flag=True,
+    callback=_show_version,
+)
+@click.pass_context
 def main(
+    ctx,
     rpc_uri,
     chain_spec_path,
     report_dir,

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,8 @@ from setuptools import setup, find_packages
 
 setup(
     name="tlbc-monitor",
-    version="0.0.1",
+    setup_requires=["setuptools_scm"],
+    use_scm_version=True,
     packages=find_packages(),
     install_requires=["click", "eth_utils", "structlog", "web3", "sqlalchemy"],
     extras_require={"test": ["eth-tester[py-evm]", "pytest"]},


### PR DESCRIPTION
This upgrades pip and co and adds a --version command line argument, which we need to tag the docker images.
