### PR TITLE
fix "main() got an unexpected keyword argument 'version'" error

### DIFF
--- a/monitor/main.py
+++ b/monitor/main.py
@@ -384,6 +384,7 @@ def main(
     skip_rate,
     offline_window_size_in_seconds,
     sync_from,
+    version,
 ):
     initial_block_resolver = blocksel.make_blockresolver(sync_from)
     offline_window_size_in_steps = offline_window_size_in_seconds // STEP_DURATION


### PR DESCRIPTION
add unused version keyword argument to main. the --version option passes an
unused version keyword argument to main.