### PR TITLE
Fix the sync message

### DIFF
--- a/monitor/main.py
+++ b/monitor/main.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import signal
 import time
 import pkg_resources
+import logging
 
 from typing import Any, NamedTuple
 
@@ -76,6 +77,9 @@ Signature of block header two:
 
 """
 
+logging.basicConfig(level=logging.INFO)
+structlog.configure(logger_factory=structlog.stdlib.LoggerFactory())
+
 
 def step_number_to_timestamp(step):
     return step * STEP_DURATION
@@ -146,10 +150,11 @@ class App:
             session.commit()
 
         self.logger.info(
-            f"Syncing ({(int(self.block_fetcher.get_sync_status_percentage()))}%) "
-            f"{format_block(self.block_fetcher.head)}",
-            head_hash=self.block_fetcher.head.hash,
-            head_number=self.block_fetcher.head.number,
+            f"Syncing ({self.block_fetcher.get_sync_status():.0%})"
+            if self.block_fetcher.syncing
+            else "Synced",
+            head=format_block(self.block_fetcher.head),
+            head_hash=self.block_fetcher.head.hash.hex(),
         )
 
         if number_of_new_blocks == 0:

--- a/monitor/skip_reporter.py
+++ b/monitor/skip_reporter.py
@@ -62,7 +62,7 @@ class SkipReporter:
         # don't report skips between genesis and the first block as genesis always has step 0
         if self.latest_step is None:
             self.latest_step = block_step
-            self.logger.info("received first block", step=self.latest_step)
+            self.logger.debug("received first block", step=self.latest_step)
             return
 
         self.update_open_skipped_proposals(block_step, block_height)


### PR DESCRIPTION
Before the sync message simply showed the percentage between genesis and
head. Now we store the start sync block number and show the percentage
of the sync from start to head. This is also corrected by the number of
blocks in the current fetched branch. If we get in the near of the
current latest block we will stop showing syncing, and start showing
syncing again if we fall too far behind.

Closes #46 