### PR TITLE
Wait for node to be fully synced

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -65,6 +65,7 @@ setuptools==41.0.1
 six==1.12.0
 SQLAlchemy==1.3.6
 structlog==19.1.0
+tenacity==5.1.1
 toml==0.10.0
 toolz==0.10.0
 tox==3.13.2

--- a/monitor/node_status.py
+++ b/monitor/node_status.py
@@ -1,0 +1,91 @@
+import logging
+from typing import Dict, List, Optional
+
+import attr
+import time
+import tenacity
+
+logger = logging.getLogger(__name__)
+
+
+@attr.s(auto_attribs=True)
+class NodeStatus:
+    is_syncing: bool
+    block_number: int
+    latest_synced_block: int
+    syncing_map: Dict
+    client_version: str
+    is_light_node: Optional[bool]
+    block_gap: List[int]
+
+
+def get_node_status_parity(w3):
+    client_version = w3.clientVersion
+    block_number = w3.eth.blockNumber
+
+    syncing_map = w3.eth.syncing or None
+
+    chain_status = w3.manager.request_blocking("parity_chainStatus", [])
+    node_kind = w3.manager.request_blocking("parity_nodeKind", [])
+
+    if chain_status.blockGap is not None:
+        block_gap = [int(x, 16) for x in chain_status.blockGap]
+    else:
+        block_gap = None
+
+    is_light_node = node_kind.capability == "light"
+
+    if block_gap and not is_light_node:  # warp mode syncing
+        is_syncing = True
+        latest_synced_block = block_gap[0] - 1
+    elif syncing_map:
+        is_syncing = True
+        latest_synced_block = syncing_map.currentBlock
+    else:
+        is_syncing = False
+        latest_synced_block = block_number
+
+    return NodeStatus(
+        is_syncing=is_syncing,
+        block_number=block_number,
+        latest_synced_block=latest_synced_block,
+        syncing_map=syncing_map,
+        client_version=client_version,
+        is_light_node=is_light_node,
+        block_gap=block_gap,
+    )
+
+
+def get_node_status_geth(w3):
+    client_version = w3.clientVersion
+    block_number = w3.eth.blockNumber
+    syncing_map = w3.eth.syncing or None
+    is_syncing = bool(syncing_map)
+    return NodeStatus(
+        is_syncing=is_syncing,
+        block_number=block_number,
+        latest_synced_block=block_number,
+        syncing_map=syncing_map,
+        client_version=client_version,
+        is_light_node=None,
+        block_gap=None,
+    )
+
+
+def get_node_status(w3):
+    if w3.clientVersion.startswith("Parity"):
+        return get_node_status_parity(w3)
+    else:
+        return get_node_status_geth(w3)
+
+
+def wait_for_node_status(w3, predicate, sleep_time=30.0):
+    retry = tenacity.retry(
+        wait=tenacity.wait_exponential(multiplier=1, min=5, max=120),
+        before_sleep=tenacity.before_sleep_log(logger, logging.WARN),
+    )
+    while True:
+        node_status = retry(get_node_status)(w3)
+        if predicate(node_status):
+            return node_status
+        time.sleep(sleep_time)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,8 @@ structlog
 web3
 sqlalchemy
 contract-deploy-tools
+attrs
+tenacity
 
 # --- development dependencies, i.e. dependencies not needed for running
 pytest

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,8 @@ setup(
         "web3",
         "sqlalchemy",
         "contract-deploy-tools",
+        "attrs",
+        "tenacity",
     ],
     extras_require={"test": ["eth-tester[py-evm]", "pytest"]},
     entry_points={


### PR DESCRIPTION
tlbc-monitor might crash if the node is not fully synced because it
calls into contract that is not synchronized yet.

This will wait until the node is fully synced.

For some cases this might result in a worse experience. When using
warp-mode, it now also waits until the gap of not-yet synchronized
blocks is gone, whereas previously it was possible to start running
the monitor.

If we want to support that again we need to put in more work and also
look at the block selector stuff, which I assume also doesn't work
with warp-mode.

So, in that sense this is the dumb solution, but it's probably good
enough for now.

Also see https://github.com/trustlines-protocol/tlbc-monitor/issues/83