### PR TITLE
Update CircleCI file to new release process

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,8 +37,63 @@ commands:
             sudo apt update
             sudo apt install -y curl make build-essential libssl-dev libsecp256k1-dev python3 python3-dev python3-distutils python3-venv pkg-config
 
+  upload-docker-image:
+    description: "Deploy docker image"
+    steps:
+      - setup_remote_docker
+      - attach_workspace:
+          at: '~'
+      - run:
+          name: Load docker image
+          command: |
+            du -hc ~/images/*
+            docker load --input ~/images/$LOCAL_IMAGE.tar
+            docker image ls
+      - run:
+          name: Login to dockerhub
+          command: |
+            echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USER" --password-stdin
+      - run:
+          name: Upload docker images
+          command: |
+            VERSION=$(docker run --rm $LOCAL_IMAGE --version | tr '+' '_')
+            CLEAN_BRANCH_NAME=${CIRCLE_BRANCH##*/}
+            echo "Tagging with $DOCKER_REPO:$VERSION and $DOCKER_REPO:$CLEAN_BRANCH_NAME"
+            docker tag $LOCAL_IMAGE $DOCKER_REPO:$VERSION
+            docker push $DOCKER_REPO:$VERSION
+            docker tag $LOCAL_IMAGE $DOCKER_REPO:$CLEAN_BRANCH_NAME
+            docker push $DOCKER_REPO:$CLEAN_BRANCH_NAME
+
+  upload-report-docker-image:
+    description: "Deploy report docker image"
+    steps:
+      - setup_remote_docker
+      - attach_workspace:
+          at: '~'
+      - run:
+          name: Load docker image
+          command: |
+            du -hc ~/images/*
+            docker load --input ~/images/$LOCAL_IMAGE.tar
+            docker image ls
+      - run:
+          name: Login to dockerhub
+          command: |
+            echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USER" --password-stdin
+      - run:
+          name: Upload docker images
+          command: |
+            CLEAN_BRANCH_NAME=${CIRCLE_BRANCH##*/}
+            echo "Tagging with $DOCKER_REPO:$CIRCLE_BUILD_NUM, $DOCKER_REPO:$CLEAN_BRANCH_NAME, and $DOCKER_REPO:latest"
+            docker tag $LOCAL_IMAGE $DOCKER_REPO:$CIRCLE_BUILD_NUM
+            docker push $DOCKER_REPO:$CIRCLE_BUILD_NUM
+            docker tag $LOCAL_IMAGE $DOCKER_REPO:$CLEAN_BRANCH_NAME
+            docker push $DOCKER_REPO:$CLEAN_BRANCH_NAME
+            docker tag $LOCAL_IMAGE $DOCKER_REPO:latest
+            docker push $DOCKER_REPO:latest
+
 jobs:
-  # install pythom and create an empty python virtualenv
+  # install python and create an empty python virtualenv
   prepare-system:
     executor: ubuntu-builder
     working_directory: ~/repo
@@ -153,6 +208,7 @@ jobs:
 
       - store_artifacts:
           path: test-reports
+
   build-docker-image:
     executor: ubuntu-builder
     environment:
@@ -165,13 +221,43 @@ jobs:
       - run:
           name: Build docker image
           command: |
-            docker build . -t tlbc-monitor
-            docker build . -t report-validator -f Dockerfile.report-validator
+            docker build . -t $LOCAL_IMAGE
       - run:
           name: Save docker image
           command: |
             mkdir -p ~/images
-            docker save --output ~/images/$LOCAL_IMAGE.tar $LOCAL_IMAGE report-validator
+            docker save --output ~/images/$LOCAL_IMAGE.tar $LOCAL_IMAGE
+      - persist_to_workspace:
+          root: "~"
+          paths:
+            - images
+
+  build-report-docker-image:
+    executor: ubuntu-builder
+    environment:
+      LOCAL_IMAGE: report-validator
+      LOCAL_MONITOR_IMAGE: tlbc-monitor
+    working_directory: ~/repo
+    steps:
+      - setup_remote_docker
+      - checkout
+      - attach_workspace:
+          at: '~'
+      - run:
+          name: Load monitor docker image
+          command: |
+            du -hc ~/images/*
+            docker load --input ~/images/$LOCAL_MONITOR_IMAGE.tar
+            docker image ls
+      - run:
+          name: Build report docker image
+          command: |
+            docker build . -t $LOCAL_IMAGE -f Dockerfile.report-validator
+      - run:
+          name: Save report docker image
+          command: |
+            mkdir -p ~/images
+            docker save --output ~/images/$LOCAL_IMAGE.tar $LOCAL_IMAGE
       - persist_to_workspace:
           root: "~"
           paths:
@@ -183,44 +269,50 @@ jobs:
       LOCAL_IMAGE: tlbc-monitor
     working_directory: ~/repo
     steps:
-      - setup_remote_docker
-      - attach_workspace:
-          at: '~'
+      - run:
+          name: set DOCKER_REPO
+          command: |
+            echo ': \"${DOCKER_REPO:=trustlines/tlbc-monitor-next}\"' >> ${BASH_ENV}
+
+          # this allows us to set DOCKER_REPO from circleci when building in a
+          # fork. makes testing easier.
+      - upload-docker-image
+
+  deploy-docker-release-image:
+    executor: ubuntu-builder
+    environment:
+      LOCAL_IMAGE: tlbc-monitor
+    working_directory: ~/repo
+    steps:
       - run:
           name: set DOCKER_REPO
           command: |
             echo ': \"${DOCKER_REPO:=trustlines/tlbc-monitor}\"' >> ${BASH_ENV}
-            echo ': \"${DOCKER_REPORT_VALIDATOR_REPO:=trustlines/report-validator}\"' >> ${BASH_ENV}
 
           # this allows us to set DOCKER_REPO from circleci when building in a
           # fork. makes testing easier.
+      - upload-docker-image
       - run:
-          name: Load docker image
-          command: |
-            echo "Loading $LOCAL_IMAGE to be uploaded to $DOCKER_REPO"
-            docker load --input ~/images/$LOCAL_IMAGE.tar
-      - run:
-          name: Login to dockerhub
-          command: |
-            echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USER" --password-stdin
-      - run:
-          name: Upload tagged release
-          command: |
-            version=$(docker run --rm $LOCAL_IMAGE --version | tr '+' '_')
-            echo "Tagging with $DOCKER_REPO:$version"
-            docker tag $LOCAL_IMAGE $DOCKER_REPO:$version
-            docker push $DOCKER_REPO:$version
-            docker tag report-validator $DOCKER_REPORT_VALIDATOR_REPO:$version
-            docker push $DOCKER_REPORT_VALIDATOR_REPO:$version
-
-      - run:
-          name: Upload latest
+          name: Upload latest image
           command: |
             echo "Tagging with $DOCKER_REPO:latest"
             docker tag $LOCAL_IMAGE $DOCKER_REPO:latest
             docker push $DOCKER_REPO:latest
-            docker tag report-validator $DOCKER_REPORT_VALIDATOR_REPO:latest
-            docker push $DOCKER_REPORT_VALIDATOR_REPO:latest
+
+  deploy-report-docker-image:
+    executor: ubuntu-builder
+    environment:
+      LOCAL_IMAGE: report-validator
+    working_directory: ~/repo
+    steps:
+      - run:
+          name: set DOCKER_REPO
+          command: |
+            echo ': \"${DOCKER_REPO:=trustlines/report-validator}\"' >> ${BASH_ENV}
+
+          # this allows us to set DOCKER_REPO from circleci when building in a
+          # fork. makes testing easier.
+      - upload-report-docker-image
 
   end2end:
     machine:
@@ -275,11 +367,26 @@ workflows:
       - build-docker-image:
           filters:
             <<: *tagged-filter
+      - build-report-docker-image:
+          filters:
+            <<: *tagged-filter
+          requires:
+            - build-docker-image
+      - approve-release:
+          type: approval
+          filters:
+            branches:
+              only:
+                - release
+          requires:
+            - build-docker-image
       - deploy-docker-image:
           filters:
             <<: *tagged-filter
             branches:
-              only: master
+              only:
+                - master
+                - pre-release
           requires:
             - run-flake8
             - run-black
@@ -287,5 +394,31 @@ workflows:
             - run-mypy
             - install
             - build-docker-image
+          context: docker-credentials
+      - deploy-docker-release-image:
+          filters:
+            <<: *tagged-filter
+            branches:
+              only:
+                - release
+          requires:
+            - run-flake8
+            - run-black
+            - run-pytest
+            - run-mypy
+            - install
+            - build-docker-image
+            - approve-release
+          context: docker-credentials
+      - deploy-report-docker-image:
+          filters:
+            <<: *tagged-filter
+          requires:
+            - run-flake8
+            - run-black
+            - run-pytest
+            - run-mypy
+            - install
+            - build-report-docker-image
           context: docker-credentials
       - end2end


### PR DESCRIPTION
- deploy everything, including pre-releases, to `trustlines/tlbc-monitor-next:$VERSION` and `:$BRANCH_NAME`
- deploy releases to `trustlines/tlbc-monitor:release` and `:latest`
- build and deploy the reporter independently of the monitor itself, without a specific release process